### PR TITLE
Show whitespace

### DIFF
--- a/src/lib/attachments/showWhitespace.ts
+++ b/src/lib/attachments/showWhitespace.ts
@@ -1,0 +1,40 @@
+import type { Attachment } from "svelte/attachments";
+
+const addWhitespace = (character: string, element: Node) => {
+    if (!(element instanceof HTMLElement)) return;
+
+    if (element.children.length > 0)
+        for (const child of element.children) addWhitespace(character, child);
+    else if (element.textContent.length > 0) {
+        element.dataset.content = element.textContent;
+        element.dataset.whitespaceContent = element.textContent
+            .replaceAll(" ", `${character}\u200B`)
+            .replaceAll(new RegExp(`[^${character}\u200B]`, "g"), "\u00A0");
+    }
+};
+
+export const showWhitespace =
+    (character: string): Attachment =>
+    (element) => {
+        addWhitespace(character, element);
+
+        const observer = new MutationObserver((records) => {
+            for (const record of records)
+                if (
+                    record.type === "characterData" &&
+                    record.target.parentElement
+                )
+                    addWhitespace(character, record.target.parentElement);
+                else if (record.type === "childList")
+                    for (const node of record.addedNodes)
+                        addWhitespace(character, node);
+        });
+
+        observer.observe(element, {
+            characterData: true,
+            childList: true,
+            subtree: true,
+        });
+
+        return () => observer.disconnect();
+    };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
 
     import { onNavigate } from "$app/navigation";
     import { page } from "$app/state";
+    import { showWhitespace } from "$lib/attachments/showWhitespace";
     import Header from "$lib/components/Header.svelte";
     import { fly } from "svelte/transition";
 
@@ -42,6 +43,7 @@
     class="grid h-full overflow-hidden motion-safe:transition-all"
     class:grid-rows-[auto_0fr]={index}
     class:grid-rows-[auto_1fr]={!index}
+    {@attach showWhitespace("\u2027")}
 >
     <Header {index} />
 
@@ -59,3 +61,21 @@
         {/key}
     </main>
 </div>
+
+<style>
+    @layer components {
+        :global([data-whitespace-content]:not([class*="before:"])) {
+            position: relative;
+
+            &::before {
+                content: attr(data-whitespace-content);
+                opacity: 50%;
+                pointer-events: none;
+
+                position: absolute;
+                inset: 0;
+                right: -1ch;
+            }
+        }
+    }
+</style>


### PR DESCRIPTION
Shows whitespace as little dots, like when you hover text in vscode.

Doesn't look too great, and breaks with floats.

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/895408a4-9a54-4ebc-9695-274beb285dd9" />
